### PR TITLE
feat: Reentrancy Guard

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -5,13 +5,14 @@ pragma solidity ^0.8.7;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
 import "@dcl/common-contracts/meta-transactions/NativeMetaTransaction.sol";
 import "@dcl/common-contracts/signatures/NonceVerifiable.sol";
 
 import "./interfaces/IERC721Rentable.sol";
 
-contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver {
+contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver, ReentrancyGuardUpgradeable {
     /// @dev EIP712 type hashes for recovering the signer from a signature.
     bytes32 private constant LISTING_TYPE_HASH =
         keccak256(
@@ -127,6 +128,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver {
         address _feeCollector,
         uint256 _fee
     ) external initializer {
+        __ReentrancyGuard_init();
         __EIP712_init("Rentals", "1");
         _setToken(_token);
         _transferOwnership(_owner);
@@ -259,7 +261,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver {
     /// @notice The original owner of the asset can claim it back if said asset is not being rented.
     /// @param _contractAddress The contract address of the asset.
     /// @param _tokenId The token id of the asset.
-    function claim(address _contractAddress, uint256 _tokenId) external {
+    function claim(address _contractAddress, uint256 _tokenId) external nonReentrant {
         address sender = _msgSender();
 
         // Verify that the rent has finished.
@@ -292,7 +294,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver {
         address _contractAddress,
         uint256 _tokenId,
         address _operator
-    ) external {
+    ) external nonReentrant {
         IERC721Rentable asset = IERC721Rentable(_contractAddress);
 
         address sender = _msgSender();
@@ -421,7 +423,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver {
         );
     }
 
-    function _rent(RentParams memory _rentParams) private {
+    function _rent(RentParams memory _rentParams) private nonReentrant {
         IERC721Rentable asset = IERC721Rentable(_rentParams.contractAddress);
 
         // If the provided contract support the verifyFingerpint function, validate the provided fingerprint.

--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -178,7 +178,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver, Ree
         uint256 _index,
         uint256 _rentalDays,
         bytes32 _fingerprint
-    ) external {
+    ) external nonReentrant {
         _verifyUnsafeTransfer(_listing.contractAddress, _listing.tokenId);
 
         // Verify that the signer provided in the listing is the one that signed it.
@@ -372,7 +372,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver, Ree
         }
     }
 
-    function _acceptOffer(Offer memory _offer, address _lessor) private {
+    function _acceptOffer(Offer memory _offer, address _lessor) private nonReentrant {
         // Verify that the signer provided in the offer is the one that signed it.
         bytes32 offerHash = _hashTypedDataV4(
             keccak256(
@@ -423,7 +423,7 @@ contract Rentals is NonceVerifiable, NativeMetaTransaction, IERC721Receiver, Ree
         );
     }
 
-    function _rent(RentParams memory _rentParams) private nonReentrant {
+    function _rent(RentParams memory _rentParams) private {
         IERC721Rentable asset = IERC721Rentable(_rentParams.contractAddress);
 
         // If the provided contract support the verifyFingerpint function, validate the provided fingerprint.

--- a/contracts/mocks/ReentrantERC721.sol
+++ b/contracts/mocks/ReentrantERC721.sol
@@ -5,19 +5,33 @@ pragma solidity ^0.8.7;
 import "../interfaces/IERC721Rentable.sol";
 import "../Rentals.sol";
 
-contract ReentrantERC721ThroughClaim is IERC721Rentable {
+contract ReentrantERC721 is IERC721Rentable {
     Rentals rentals;
-    uint256 tokenId;
+    bytes data;
 
-    constructor(Rentals _rentals, uint256 _tokenId) {
+    constructor(Rentals _rentals) {
         rentals = _rentals;
-        tokenId = _tokenId;
     }
 
-    /// @dev This function is called on every _rent.
-    /// If Rentals.claim has a reentrancy guard, this should revert.
+    /// @dev set the function data that will be called through the rentals contract on setUpdateOperator.
+    /// This is intended to test reentrancy attacks, so make sure that the function data is of a public/external
+    /// Rentals function.
+    function setData(bytes memory _data) external {
+        data = _data;
+    }
+
+    /// @dev This function is called on every _rent so it will be a convenient way of testing reentrancies.
+    /// Will bubble up the error
     function setUpdateOperator(uint256, address) external override {
-        rentals.claim(address(this), tokenId);
+        (bool success, bytes memory returnData) = address(rentals).call(data);
+
+        if (!success) {
+            assembly {
+                returnData := add(returnData, 0x04)
+            }
+
+            revert(abi.decode(returnData, (string)));
+        }
     }
 
     // Ignored

--- a/contracts/mocks/ReentrantERC721ThroughClaim.sol
+++ b/contracts/mocks/ReentrantERC721ThroughClaim.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.7;
+
+import "../interfaces/IERC721Rentable.sol";
+import "../Rentals.sol";
+
+contract ReentrantERC721ThroughClaim is IERC721Rentable {
+    Rentals rentals;
+    uint256 tokenId;
+
+    constructor(Rentals _rentals, uint256 _tokenId) {
+        rentals = _rentals;
+        tokenId = _tokenId;
+    }
+
+    /// @dev This function is called on every _rent.
+    /// If Rentals.claim has a reentrancy guard, this should revert.
+    function setUpdateOperator(uint256, address) external override {
+        rentals.claim(address(this), tokenId);
+    }
+
+    // Ignored
+
+    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {}
+
+    function balanceOf(address owner) external view override returns (uint256 balance) {}
+
+    function ownerOf(uint256 tokenId) external view override returns (address owner) {}
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external override {}
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external override {}
+
+    function approve(address to, uint256 tokenId) external override {}
+
+    function getApproved(uint256 tokenId) external view override returns (address operator) {}
+
+    function setApprovalForAll(address operator, bool _approved) external override {}
+
+    function isApprovedForAll(address owner, address operator) external view override returns (bool) {}
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes calldata data
+    ) external override {}
+
+    function verifyFingerprint(uint256, bytes memory) external view override returns (bool) {}
+}

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -2246,10 +2246,15 @@ describe('Rentals', () => {
     })
 
     it('should revert when the contract is reentered through the claim function', async () => {
-      const ReentrantERC721ThroughClaimFactory = await ethers.getContractFactory('ReentrantERC721ThroughClaim')
-      const reentrantERC721 = await ReentrantERC721ThroughClaimFactory.connect(deployer).deploy(rentals.address, offerParams.tokenId)
+      const ReentrantERC721Factory = await ethers.getContractFactory('ReentrantERC721')
+      const reentrantERC721 = await ReentrantERC721Factory.connect(deployer).deploy(rentals.address)
 
       offerParams = { ...offerParams, contractAddress: reentrantERC721.address }
+
+      const abi = ['function claim(address _contractAddress, uint256 _tokenId)']
+      const iface = new ethers.utils.Interface(abi)
+      const functionData = iface.encodeFunctionData('claim', [reentrantERC721.address, offerParams.tokenId])
+      await reentrantERC721.setData(functionData)
 
       await expect(
         rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -2244,6 +2244,17 @@ describe('Rentals', () => {
 
       await expect(rentals.connect(tenant).claim(land.address, tokenId)).to.be.revertedWith('Rentals#claim: NOT_LESSOR')
     })
+
+    it('should revert when the contract is reentered through the claim function', async () => {
+      const ReentrantERC721ThroughClaimFactory = await ethers.getContractFactory('ReentrantERC721ThroughClaim')
+      const reentrantERC721 = await ReentrantERC721ThroughClaimFactory.connect(deployer).deploy(rentals.address, offerParams.tokenId)
+
+      offerParams = { ...offerParams, contractAddress: reentrantERC721.address }
+
+      await expect(
+        rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
+      ).to.be.revertedWith('ReentrancyGuard: reentrant call')
+    })
   })
 
   describe('setOperator', () => {

--- a/test/utils/rentals.ts
+++ b/test/utils/rentals.ts
@@ -162,3 +162,159 @@ export const getMetaTxSignature = async (signer: SignerWithAddress, contract: Re
     params
   )
 }
+
+export const acceptListingABI = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'signer',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'contractAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'tokenId',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'expiration',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256[3]',
+            name: 'nonces',
+            type: 'uint256[3]',
+          },
+          {
+            internalType: 'uint256[]',
+            name: 'pricePerDay',
+            type: 'uint256[]',
+          },
+          {
+            internalType: 'uint256[]',
+            name: 'maxDays',
+            type: 'uint256[]',
+          },
+          {
+            internalType: 'uint256[]',
+            name: 'minDays',
+            type: 'uint256[]',
+          },
+          {
+            internalType: 'address',
+            name: 'target',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Rentals.Listing',
+        name: '_listing',
+        type: 'tuple',
+      },
+      {
+        internalType: 'address',
+        name: '_operator',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_index',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_rentalDays',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_fingerprint',
+        type: 'bytes32',
+      },
+    ],
+    name: 'acceptListing',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]
+
+export const acceptOfferABI = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'signer',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'contractAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'tokenId',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'expiration',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256[3]',
+            name: 'nonces',
+            type: 'uint256[3]',
+          },
+          {
+            internalType: 'uint256',
+            name: 'pricePerDay',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'rentalDays',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'operator',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'fingerprint',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Rentals.Offer',
+        name: '_offer',
+        type: 'tuple',
+      },
+    ],
+    name: 'acceptOffer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]


### PR DESCRIPTION
Added nonReentrant modifier to functions that call arbitrary contracts:
- setOperator
- claim
- acceptListing
- _acceptOffer (which includes acceptOffer and onERC721Received)