### PR TITLE
feat: Private state vars

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -46,17 +46,17 @@ contract Rentals is
     bytes4 private constant InterfaceId_OnERC721Received = bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"));
 
     /// @notice ERC20 token used to pay for rent and fees.
-    IERC20 public token;
+    IERC20 private token;
 
     /// @notice Tracks necessary rental data per asset.
     /// @custom:schema (contract address -> token id -> lessor address)
-    mapping(address => mapping(uint256 => Rental)) public rentals;
+    mapping(address => mapping(uint256 => Rental)) private rentals;
 
     /// @notice Address that will receive ERC20 tokens collected as rental fees.
-    address public feeCollector;
+    address private feeCollector;
 
     /// @notice Value per million wei that will be deducted from the rental price and sent to the collector.
-    uint256 public fee;
+    uint256 private fee;
 
     /// @notice Struct received as a parameter in `acceptListing` containing all information about
     /// listing conditions and values required to verify the signature was created by the signer.
@@ -141,10 +141,40 @@ contract Rentals is
         __ReentrancyGuard_init();
         __NativeMetaTransaction_init("Rentals", "1");
         __ContractNonceVerifiable_init();
-        _setToken(_token);
         _transferOwnership(_owner);
+        _setToken(_token);
         _setFeeCollector(_feeCollector);
         _setFee(_fee);
+    }
+
+    /// @notice Get the rental data for a given asset.
+    /// @param _contractAddress The contract address of the asset.
+    /// @param _tokenId The id of the asset.
+    function getRental(address _contractAddress, uint256 _tokenId) external view returns (Rental memory) {
+        return rentals[_contractAddress][_tokenId];
+    }
+
+    /// @notice Get the current token address used for rental payments.
+    function getToken() external view returns (IERC20) {
+        return token;
+    }
+
+    /// @notice Get the current address that will receive a cut of rental payments as a fee.
+    function getFeeCollector() external view returns (address) {
+        return feeCollector;
+    }
+
+    /// @notice Get the value per MAX_FEE that will be cut from the rental payment and sent to the fee collector.
+    function getFee() external view returns (uint256) {
+        return fee;
+    }
+
+    /// @notice Get if and asset is currently being rented.
+    /// @param _contractAddress The contract address of the asset.
+    /// @param _tokenId The token id of the asset.
+    /// @return result true or false depending if the asset is currently rented
+    function getIsRented(address _contractAddress, uint256 _tokenId) public view returns (bool result) {
+        result = block.timestamp <= rentals[_contractAddress][_tokenId].endDate;
     }
 
     /// @notice Set the ERC20 token used by tenants to pay rent.
@@ -163,14 +193,6 @@ contract Rentals is
     /// @param _fee The value for the fee.
     function setFee(uint256 _fee) external onlyOwner {
         _setFee(_fee);
-    }
-
-    /// @notice Get if and asset is currently being rented.
-    /// @param _contractAddress The contract address of the asset.
-    /// @param _tokenId The token id of the asset.
-    /// @return result true or false depending if the asset is currently rented
-    function isRented(address _contractAddress, uint256 _tokenId) public view returns (bool result) {
-        result = block.timestamp <= rentals[_contractAddress][_tokenId].endDate;
     }
 
     /// @notice Accept a rental listing created by the owner of an asset.
@@ -268,7 +290,7 @@ contract Rentals is
             uint256 tokenId = _tokenIds[i];
 
             // Verify that the rent has finished.
-            require(!isRented(contractAddress, tokenId), "Rentals#claim: CURRENTLY_RENTED");
+            require(!getIsRented(contractAddress, tokenId), "Rentals#claim: CURRENTLY_RENTED");
 
             Rental memory rental = rentals[contractAddress][tokenId];
 
@@ -312,10 +334,10 @@ contract Rentals is
             address contractAddress = _contractAddresses[i];
             uint256 tokenId = _tokenIds[i];
             Rental memory rental = rentals[contractAddress][tokenId];
-            bool rented = isRented(contractAddress, tokenId);
+            bool isRented = getIsRented(contractAddress, tokenId);
 
             require(
-                (rented && sender == rental.tenant) || (!rented && sender == rental.lessor),
+                (isRented && sender == rental.tenant) || (!isRented && sender == rental.lessor),
                 "Rentals#setUpdateOperator: CANNOT_SET_UPDATE_OPERATOR"
             );
 
@@ -340,11 +362,11 @@ contract Rentals is
         require(_landTokenIds.length == _operators.length, "Rentals#setManyLandUpdateOperator: LENGTH_MISMATCH");
 
         Rental memory rental = rentals[_contractAddress][_tokenId];
-        bool rented = isRented(_contractAddress, _tokenId);
+        bool isRented = getIsRented(_contractAddress, _tokenId);
         address sender = _msgSender();
 
         require(
-            (rented && sender == rental.tenant) || (!rented && sender == rental.lessor),
+            (isRented && sender == rental.tenant) || (!isRented && sender == rental.lessor),
             "Rentals#setManyLandUpdateOperator: CANNOT_SET_MANY_LAND_UPDATE_OPERATOR"
         );
 
@@ -503,24 +525,24 @@ contract Rentals is
         Rental storage rental = rentals[_rentParams.contractAddress][_rentParams.tokenId];
 
         // True if the asset is currently rented.
-        bool rented = isRented(_rentParams.contractAddress, _rentParams.tokenId);
+        bool isRented = getIsRented(_rentParams.contractAddress, _rentParams.tokenId);
         // True if the asset rental period is over, but is has not been claimed back from the contract.
-        bool reRent = !rented && rental.lessor != address(0);
+        bool isReRent = !isRented && rental.lessor != address(0);
         // True if the asset rental period is not over yet, but the lessor and the tenant are the same.
-        bool extend = rented && rental.lessor == _rentParams.lessor && rental.tenant == _rentParams.tenant;
+        bool isExtend = isRented && rental.lessor == _rentParams.lessor && rental.tenant == _rentParams.tenant;
 
-        if (!extend && !reRent) {
+        if (!isExtend && !isReRent) {
             // Verify that the asset is not already rented.
-            require(!rented, "Rentals#_rent: CURRENTLY_RENTED");
+            require(!isRented, "Rentals#_rent: CURRENTLY_RENTED");
         }
 
-        if (reRent) {
+        if (isReRent) {
             // The asset is being rented again wihout claiming it back first, so we need to check that the previous lessor
             // is the same as the lessor this time to prevent anyone else from acting as the lessor.
             require(rental.lessor == _rentParams.lessor, "Rentals#_rent: NOT_ORIGINAL_OWNER");
         }
 
-        if (extend) {
+        if (isExtend) {
             // Increase the current end date by the amount of provided rental days.
             rental.endDate = rental.endDate + _rentParams.rentalDays * 1 days;
         } else {
@@ -544,7 +566,7 @@ contract Rentals is
         }
 
         // Only transfer the ERC721 to this contract if it doesn't already have it.
-        if (!extend && !reRent && _ownerOf(address(asset), _rentParams.tokenId) != address(this)) {
+        if (!isExtend && !isReRent && _ownerOf(address(asset), _rentParams.tokenId) != address(this)) {
             asset.safeTransferFrom(_rentParams.lessor, address(this), _rentParams.tokenId);
         }
 
@@ -559,7 +581,7 @@ contract Rentals is
             _rentParams.operator,
             _rentParams.rentalDays,
             _rentParams.pricePerDay,
-            extend,
+            isExtend,
             _msgSender(),
             _rentParams.signature
         );

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -178,15 +178,15 @@ describe('Rentals', () => {
     })
 
     it('should set the erc20 token', async () => {
-      expect(await rentals.token()).to.be.equal(mana.address)
+      expect(await rentals.getToken()).to.be.equal(mana.address)
     })
 
     it('should set the fee collector', async () => {
-      expect(await rentals.feeCollector()).to.be.equal(collector.address)
+      expect(await rentals.getFeeCollector()).to.be.equal(collector.address)
     })
 
     it('should set the fee', async () => {
-      expect(await rentals.fee()).to.be.equal(fee)
+      expect(await rentals.getFee()).to.be.equal(fee)
     })
 
     it('should set eip712 name and version hashes', async () => {
@@ -224,7 +224,7 @@ describe('Rentals', () => {
 
     it('should update the erc20 token variable', async () => {
       await rentals.connect(owner).setToken(newToken)
-      expect(await rentals.token()).to.be.equal(newToken)
+      expect(await rentals.getToken()).to.be.equal(newToken)
     })
 
     it('should emit a TokenUpdated event', async () => {
@@ -239,7 +239,7 @@ describe('Rentals', () => {
 
       await rentals.connect(owner).executeMetaTransaction(owner.address, functionData, metaTxSignature)
 
-      expect(await rentals.token()).to.be.equal(newToken)
+      expect(await rentals.getToken()).to.be.equal(newToken)
     })
 
     it('should revert when sender is not owner', async () => {
@@ -260,7 +260,7 @@ describe('Rentals', () => {
 
     it('should update the feeCollector variable', async () => {
       await rentals.connect(owner).setFeeCollector(newFeeCollector)
-      expect(await rentals.feeCollector()).to.be.equal(newFeeCollector)
+      expect(await rentals.getFeeCollector()).to.be.equal(newFeeCollector)
     })
 
     it('should emit a FeeCollectorUpdated event', async () => {
@@ -277,7 +277,7 @@ describe('Rentals', () => {
 
       await rentals.connect(owner).executeMetaTransaction(owner.address, functionData, metaTxSignature)
 
-      expect(await rentals.feeCollector()).to.be.equal(newFeeCollector)
+      expect(await rentals.getFeeCollector()).to.be.equal(newFeeCollector)
     })
 
     it('should revert when sender is not owner', async () => {
@@ -295,7 +295,7 @@ describe('Rentals', () => {
 
     it('should update the fee variable', async () => {
       await rentals.connect(owner).setFee(newFee)
-      expect(await rentals.fee()).to.be.equal(newFee)
+      expect(await rentals.getFee()).to.be.equal(newFee)
     })
 
     it('should emit a FeeUpdated event', async () => {
@@ -305,7 +305,7 @@ describe('Rentals', () => {
     it('should accept the maximum fee of MAX_FEE', async () => {
       const maximumFee = '1000000'
       await rentals.connect(owner).setFee(maximumFee)
-      expect(await rentals.fee()).to.be.equal(maximumFee)
+      expect(await rentals.getFee()).to.be.equal(maximumFee)
     })
 
     it('should accept a meta tx', async () => {
@@ -316,7 +316,7 @@ describe('Rentals', () => {
 
       await rentals.connect(owner).executeMetaTransaction(owner.address, functionData, metaTxSignature)
 
-      expect(await rentals.fee()).to.be.equal(newFee)
+      expect(await rentals.getFee()).to.be.equal(newFee)
     })
 
     it('should revert when sender is not owner', async () => {
@@ -422,13 +422,13 @@ describe('Rentals', () => {
     })
 
     it('should return false when the asset was never rented', async () => {
-      expect(await rentals.isRented(land.address, tokenId)).to.equal(false)
+      expect(await rentals.getIsRented(land.address, tokenId)).to.equal(false)
     })
 
     it('should return true after an asset is rented', async () => {
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect(await rentals.isRented(land.address, tokenId)).to.equal(true)
+      expect(await rentals.getIsRented(land.address, tokenId)).to.equal(true)
     })
 
     it('should return true when the current block timestamp is the same as the rental end', async () => {
@@ -438,11 +438,11 @@ describe('Rentals', () => {
       await evmMine()
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
-      const rentalEnd = (await rentals.rentals(land.address, tokenId)).endDate
+      const rentalEnd = (await rentals.getRental(land.address, tokenId)).endDate
 
       expect(rentalEnd).to.be.equal(latestBlockTimestamp)
 
-      expect(await rentals.isRented(land.address, tokenId)).to.equal(true)
+      expect(await rentals.getIsRented(land.address, tokenId)).to.equal(true)
     })
 
     it('should return false when the block timestamp is equal to the rental end + 1', async () => {
@@ -451,7 +451,7 @@ describe('Rentals', () => {
       await evmIncreaseTime(daysToSeconds(offerParams.rentalDays) + 1)
       await evmMine()
 
-      expect(await rentals.isRented(land.address, tokenId)).to.equal(false)
+      expect(await rentals.getIsRented(land.address, tokenId)).to.equal(false)
     })
   })
 
@@ -602,7 +602,7 @@ describe('Rentals', () => {
     })
 
     it('should update the rentals mapping with lessor when the contract does not own the asset already', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(zeroAddress)
 
       await rentals
         .connect(tenant)
@@ -614,11 +614,11 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(lessor.address)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(lessor.address)
     })
 
     it('should update the rentals mapping with new tenant', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(zeroAddress)
 
       await rentals
         .connect(tenant)
@@ -630,7 +630,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(tenant.address)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(tenant.address)
     })
 
     it('should bump both the lessor and tenant asset nonces', async () => {
@@ -652,7 +652,7 @@ describe('Rentals', () => {
     })
 
     it('should update the rentals mapping with the end timestamp of the rented asset', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).endDate).to.equal(0)
+      expect((await rentals.getRental(land.address, tokenId)).endDate).to.equal(0)
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
@@ -666,7 +666,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(land.address, tokenId)).endDate).to.equal(latestBlockTimestamp + daysToSeconds(offerParams.rentalDays) + 1)
+      expect((await rentals.getRental(land.address, tokenId)).endDate).to.equal(latestBlockTimestamp + daysToSeconds(offerParams.rentalDays) + 1)
     })
 
     it('should increase the end date of a rental on an extension by the provided rental days', async () => {
@@ -684,7 +684,7 @@ describe('Rentals', () => {
 
       let endDate = latestBlockTimestamp + daysToSeconds(acceptListingParams.rentalDays)
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
 
       expect(rental.endDate).to.equal(endDate)
 
@@ -706,7 +706,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
 
       endDate += daysToSeconds(acceptListingParams.rentalDays)
 
@@ -717,7 +717,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -743,7 +743,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -767,7 +767,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -784,7 +784,7 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))
@@ -800,7 +800,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -826,7 +826,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -841,7 +841,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -858,7 +858,7 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))
@@ -968,7 +968,7 @@ describe('Rentals', () => {
     it('should accept the listing when the caller is the same as the target provided', async () => {
       listingParams = { ...listingParams, target: tenant.address }
 
-      expect((await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(zeroAddress)
 
       await rentals
         .connect(tenant)
@@ -980,11 +980,11 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(tenant.address)
+      expect((await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(tenant.address)
     })
 
     it('should allow a re rent if the lessor is the same', async () => {
-      expect((await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(zeroAddress)
 
       await rentals
         .connect(tenant)
@@ -996,7 +996,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(tenant.address)
+      expect((await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(tenant.address)
 
       await evmIncreaseTime((await getLatestBlockTimestamp()) + daysToSeconds(acceptListingParams.rentalDays))
       await evmMine()
@@ -1013,7 +1013,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      expect((await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(extra.address)
+      expect((await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)).tenant).to.equal(extra.address)
     })
 
     it('should accept a meta tx', async () => {
@@ -1632,19 +1632,19 @@ describe('Rentals', () => {
     })
 
     it('should update rentals mapping with lessor when the contract does not own the asset already', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(zeroAddress)
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(lessor.address)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(lessor.address)
     })
 
     it('should update the rentals mapping with new tenant', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(zeroAddress)
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(tenant.address)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(tenant.address)
     })
 
     it('should bump both the lessor and tenant asset nonces', async () => {
@@ -1658,13 +1658,13 @@ describe('Rentals', () => {
     })
 
     it('should update the rentals mapping for the rented asset with the rental finish timestamp', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).endDate).to.equal(0)
+      expect((await rentals.getRental(land.address, tokenId)).endDate).to.equal(0)
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect((await rentals.rentals(land.address, tokenId)).endDate).to.equal(latestBlockTimestamp + daysToSeconds(offerParams.rentalDays) + 1)
+      expect((await rentals.getRental(land.address, tokenId)).endDate).to.equal(latestBlockTimestamp + daysToSeconds(offerParams.rentalDays) + 1)
     })
 
     it('should increase the end date of a rental on an extension by the provided rental days', async () => {
@@ -1674,7 +1674,7 @@ describe('Rentals', () => {
 
       let endDate = latestBlockTimestamp + daysToSeconds(offerParams.rentalDays)
 
-      let rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      let rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       expect(rental.endDate).to.equal(endDate)
 
@@ -1687,7 +1687,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       endDate += daysToSeconds(offerParams.rentalDays)
 
@@ -1698,7 +1698,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -1715,7 +1715,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -1730,7 +1730,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -1747,7 +1747,7 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))
@@ -1763,7 +1763,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -1780,7 +1780,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -1804,7 +1804,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -1821,7 +1821,7 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))
@@ -2093,33 +2093,33 @@ describe('Rentals', () => {
     })
 
     it('should set the lessor to address(0)', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(zeroAddress)
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(lessor.address)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(lessor.address)
 
       await evmIncreaseTime(daysToSeconds(offerParams.rentalDays))
       await evmMine()
 
       await rentals.connect(lessor).claim([land.address], [tokenId])
 
-      expect((await rentals.rentals(land.address, tokenId)).lessor).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).lessor).to.equal(zeroAddress)
     })
 
     it('should set tenant to address(0)', async () => {
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(zeroAddress)
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(tenant.address)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(tenant.address)
 
       await evmIncreaseTime(daysToSeconds(offerParams.rentalDays))
       await evmMine()
 
       await rentals.connect(lessor).claim([land.address], [tokenId])
 
-      expect((await rentals.rentals(land.address, tokenId)).tenant).to.equal(zeroAddress)
+      expect((await rentals.getRental(land.address, tokenId)).tenant).to.equal(zeroAddress)
     })
 
     it('should transfer the asset to the original owner', async () => {
@@ -2923,7 +2923,7 @@ describe('Rentals', () => {
       await evmMine()
 
       // Check that it reverts after the rental.
-      expect(await rentals.isRented(offerParams.contractAddress, offerParams.tokenId)).to.be.false
+      expect(await rentals.getIsRented(offerParams.contractAddress, offerParams.tokenId)).to.be.false
 
       await expect(rentals.connect(extra).setManyLandUpdateOperator(estate.address, estateId, [landIds], [operator.address])).to.be.revertedWith(
         'Rentals#setManyLandUpdateOperator: CANNOT_SET_MANY_LAND_UPDATE_OPERATOR'
@@ -2988,13 +2988,13 @@ describe('Rentals', () => {
 
       const bytes = ethers.utils.defaultAbiCoder.encode([offerEncodeType], [offerEncodeValue])
 
-      let rental = await rentals.rentals(offerEncodeValue[contractAddressIndex], offerEncodeValue[tokenIdIndex])
+      let rental = await rentals.getRental(offerEncodeValue[contractAddressIndex], offerEncodeValue[tokenIdIndex])
 
       expect(rental.lessor).to.equal(zeroAddress)
 
       await land.connect(extra)['safeTransferFrom(address,address,uint256,bytes)'](lessor.address, rentals.address, tokenId, bytes)
 
-      rental = await rentals.rentals(offerEncodeValue[contractAddressIndex], offerEncodeValue[tokenIdIndex])
+      rental = await rentals.getRental(offerEncodeValue[contractAddressIndex], offerEncodeValue[tokenIdIndex])
 
       expect(rental.lessor).to.equal(extra.address)
 
@@ -3037,7 +3037,7 @@ describe('Rentals', () => {
     it('should accept an offer by transfering the asset to the rentals contract with the offer data', async () => {
       expect(await land.ownerOf(tokenId)).to.equal(lessor.address)
 
-      let rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      let rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
@@ -3049,7 +3049,7 @@ describe('Rentals', () => {
 
       expect(await land.ownerOf(tokenId)).to.equal(rentals.address)
 
-      rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
@@ -3067,7 +3067,7 @@ describe('Rentals', () => {
 
       let endDate = latestBlockTimestamp + daysToSeconds(offerParams.rentalDays)
 
-      let rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      let rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       expect(rental.endDate).to.equal(endDate)
 
@@ -3080,7 +3080,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(offerParams.contractAddress, offerParams.tokenId)
+      rental = await rentals.getRental(offerParams.contractAddress, offerParams.tokenId)
 
       endDate += daysToSeconds(offerParams.rentalDays)
 
@@ -3096,7 +3096,7 @@ describe('Rentals', () => {
 
       let endDate = latestBlockTimestamp + daysToSeconds(acceptListingParams.rentalDays)
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
 
       expect(rental.endDate).to.equal(endDate)
 
@@ -3118,7 +3118,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
 
       endDate += daysToSeconds(acceptListingParams.rentalDays)
 
@@ -3129,7 +3129,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -3149,7 +3149,7 @@ describe('Rentals', () => {
 
       await land.connect(lessor)['safeTransferFrom(address,address,uint256,bytes)'](lessor.address, rentals.address, tokenId, bytes)
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -3173,7 +3173,7 @@ describe('Rentals', () => {
           acceptListingParams.fingerprint
         )
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -3190,7 +3190,7 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))
@@ -3206,7 +3206,7 @@ describe('Rentals', () => {
       const rentalDays1 = 10
       const rentalDays2 = 100
 
-      let rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      let rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(zeroAddress)
       expect(rental.tenant).to.equal(zeroAddress)
       expect(rental.endDate).to.equal(0)
@@ -3226,7 +3226,7 @@ describe('Rentals', () => {
 
       await land.connect(lessor)['safeTransferFrom(address,address,uint256,bytes)'](lessor.address, rentals.address, tokenId, bytes)
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1) + 1)
@@ -3241,7 +3241,7 @@ describe('Rentals', () => {
 
       await rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId, { blockTag: 'pending' })
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal((await getLatestBlockTimestamp()) + daysToSeconds(rentalDays1 + rentalDays2) + 1)
@@ -3258,9 +3258,9 @@ describe('Rentals', () => {
 
       const latestBlockTimestamp = await getLatestBlockTimestamp()
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
 
-      rental = await rentals.rentals(listingParams.contractAddress, listingParams.tokenId)
+      rental = await rentals.getRental(listingParams.contractAddress, listingParams.tokenId)
       expect(rental.lessor).to.equal(lessor.address)
       expect(rental.tenant).to.equal(tenant.address)
       expect(rental.endDate).to.equal(latestBlockTimestamp + daysToSeconds(rentalDays1 + rentalDays2))


### PR DESCRIPTION
Made public contract variables private.
Renamed `isRented` to `getIsRented`
Standardized boolean naming to `isSomething` instead of just `something`