### PR TITLE
feat: Pausable

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import "@dcl/common-contracts/meta-transactions/NativeMetaTransaction.sol";
 import "@dcl/common-contracts/signatures/ContractNonceVerifiable.sol";
@@ -20,7 +21,8 @@ contract Rentals is
     AssetNonceVerifiable,
     NativeMetaTransaction,
     IERC721Receiver,
-    ReentrancyGuardUpgradeable
+    ReentrancyGuardUpgradeable,
+    PausableUpgradeable
 {
     /// @dev EIP712 type hashes for recovering the signer from a signature.
     bytes32 private constant LISTING_TYPE_HASH =
@@ -140,12 +142,32 @@ contract Rentals is
         uint256 _fee
     ) external initializer {
         __ReentrancyGuard_init();
+        __Pausable_init();
         __NativeMetaTransaction_init("Rentals", "1");
         __ContractNonceVerifiable_init();
         _transferOwnership(_owner);
         _setToken(_token);
         _setFeeCollector(_feeCollector);
         _setFee(_fee);
+    }
+
+    /// @notice Pause the contract and prevent core functions from being called.
+    /// Functions that will be paused are:
+    /// - acceptListing
+    /// - acceptOffer
+    /// - onERC721Received (No offers will be accepted through a safeTransfer to this contract)
+    /// - claim
+    /// - setUpdateOperator
+    /// - setManyLandUpdateOperator
+    /// @dev The contract has to be unpaused or this function will revert.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume the normal functionallity of the contract.
+    /// @dev The contract has to be paused or this function will revert.
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     /// @notice Get the rental data for a given asset.
@@ -212,7 +234,7 @@ contract Rentals is
         uint256 _index,
         uint256 _rentalDays,
         bytes32 _fingerprint
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         _verifyUnsafeTransfer(_listing.contractAddress, _listing.tokenId);
 
         address lessor = _listing.signer;
@@ -284,7 +306,7 @@ contract Rentals is
     /// @param _contractAddresses The contract address of the assets to be claimed.
     /// @param _tokenIds The token ids of the assets to be claimed.
     /// Each tokenId corresponds to a contract address in the same index.
-    function claim(address[] memory _contractAddresses, uint256[] memory _tokenIds) external nonReentrant {
+    function claim(address[] memory _contractAddresses, uint256[] memory _tokenIds) external nonReentrant whenNotPaused {
         address sender = _msgSender();
 
         require(_contractAddresses.length == _tokenIds.length, "Rentals#claim: LENGTH_MISMATCH");
@@ -326,7 +348,7 @@ contract Rentals is
         address[] memory _contractAddresses,
         uint256[] memory _tokenIds,
         address[] memory _operators
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         require(
             _contractAddresses.length == _tokenIds.length && _contractAddresses.length == _operators.length,
             "Rentals#setUpdateOperator: LENGTH_MISMATCH"
@@ -362,7 +384,7 @@ contract Rentals is
         uint256 _tokenId,
         uint256[][] memory _landTokenIds,
         address[] memory _operators
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         require(_landTokenIds.length == _operators.length, "Rentals#setManyLandUpdateOperator: LENGTH_MISMATCH");
 
         Rental memory rental = rentals[_contractAddress][_tokenId];
@@ -437,7 +459,7 @@ contract Rentals is
         }
     }
 
-    function _acceptOffer(Offer memory _offer, address _lessor) private nonReentrant {
+    function _acceptOffer(Offer memory _offer, address _lessor) private nonReentrant whenNotPaused {
         address tenant = _offer.signer;
 
         require(_lessor != tenant, "Rentals#acceptOffer: CALLER_CANNOT_BE_SIGNER");

--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -157,8 +157,6 @@ contract Rentals is
     /// - acceptOffer
     /// - onERC721Received (No offers will be accepted through a safeTransfer to this contract)
     /// - claim
-    /// - setUpdateOperator
-    /// - setManyLandUpdateOperator
     /// @dev The contract has to be unpaused or this function will revert.
     function pause() external onlyOwner {
         _pause();
@@ -348,7 +346,7 @@ contract Rentals is
         address[] memory _contractAddresses,
         uint256[] memory _tokenIds,
         address[] memory _operators
-    ) external nonReentrant whenNotPaused {
+    ) external nonReentrant {
         require(
             _contractAddresses.length == _tokenIds.length && _contractAddresses.length == _operators.length,
             "Rentals#setUpdateOperator: LENGTH_MISMATCH"
@@ -384,7 +382,7 @@ contract Rentals is
         uint256 _tokenId,
         uint256[][] memory _landTokenIds,
         address[] memory _operators
-    ) external nonReentrant whenNotPaused {
+    ) external nonReentrant {
         require(_landTokenIds.length == _operators.length, "Rentals#setManyLandUpdateOperator: LENGTH_MISMATCH");
 
         Rental memory rental = rentals[_contractAddress][_tokenId];

--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -157,6 +157,8 @@ contract Rentals is
     /// - acceptOffer
     /// - onERC721Received (No offers will be accepted through a safeTransfer to this contract)
     /// - claim
+    /// - setUpdateOperator
+    /// - setManyLandUpdateOperator
     /// @dev The contract has to be unpaused or this function will revert.
     function pause() external onlyOwner {
         _pause();
@@ -346,7 +348,7 @@ contract Rentals is
         address[] memory _contractAddresses,
         uint256[] memory _tokenIds,
         address[] memory _operators
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         require(
             _contractAddresses.length == _tokenIds.length && _contractAddresses.length == _operators.length,
             "Rentals#setUpdateOperator: LENGTH_MISMATCH"
@@ -382,7 +384,7 @@ contract Rentals is
         uint256 _tokenId,
         uint256[][] memory _landTokenIds,
         address[] memory _operators
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         require(_landTokenIds.length == _operators.length, "Rentals#setManyLandUpdateOperator: LENGTH_MISMATCH");
 
         Rental memory rental = rentals[_contractAddress][_tokenId];

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -3788,6 +3788,16 @@ describe('Rentals', () => {
       expect(await rentals.paused()).to.be.true
     })
 
+    it('should allow calling setUpdateOperator when the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setUpdateOperator([], [], [])).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling setManyLandUpdateOperator when the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.not.be.revertedWith('Pausable: paused')
+    })
+
     it('should revert when the caller is not the owner', async () => {
       await expect(rentals.pause()).to.be.revertedWith('Ownable: caller is not the owner')
     })
@@ -3834,16 +3844,6 @@ describe('Rentals', () => {
     it('should revert when calling claim and the contract is paused', async () => {
       await rentals.connect(owner).pause()
       await expect(rentals.claim([], [])).to.be.revertedWith('Pausable: paused')
-    })
-
-    it('should revert when calling setUpdateOperator and the contract is paused', async () => {
-      await rentals.connect(owner).pause()
-      await expect(rentals.setUpdateOperator([], [], [])).to.be.revertedWith('Pausable: paused')
-    })
-
-    it('should revert when calling setManyLandUpdateOperator and the contract is paused', async () => {
-      await rentals.connect(owner).pause()
-      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.be.revertedWith('Pausable: paused')
     })
   })
 

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -3788,16 +3788,6 @@ describe('Rentals', () => {
       expect(await rentals.paused()).to.be.true
     })
 
-    it('should allow calling setUpdateOperator when the contract is paused', async () => {
-      await rentals.connect(owner).pause()
-      await expect(rentals.setUpdateOperator([], [], [])).to.not.be.revertedWith('Pausable: paused')
-    })
-
-    it('should allow calling setManyLandUpdateOperator when the contract is paused', async () => {
-      await rentals.connect(owner).pause()
-      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.not.be.revertedWith('Pausable: paused')
-    })
-
     it('should revert when the caller is not the owner', async () => {
       await expect(rentals.pause()).to.be.revertedWith('Ownable: caller is not the owner')
     })
@@ -3844,6 +3834,16 @@ describe('Rentals', () => {
     it('should revert when calling claim and the contract is paused', async () => {
       await rentals.connect(owner).pause()
       await expect(rentals.claim([], [])).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling setUpdateOperator and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setUpdateOperator([], [], [])).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling setManyLandUpdateOperator and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.be.revertedWith('Pausable: paused')
     })
   })
 

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -206,6 +206,10 @@ describe('Rentals', () => {
       expect(await rentals.getEIP712VersionHash()).to.be.equal('0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6')
     })
 
+    it('should set the contract as unpaused', async () => {
+      expect(await rentals.paused()).to.be.false
+    })
+
     it('should revert when initialized more than once', async () => {
       await expect(rentals.connect(deployer).initialize(owner.address, mana.address, collector.address, fee)).to.be.revertedWith(
         'Initializable: contract is already initialized'
@@ -3771,6 +3775,156 @@ describe('Rentals', () => {
       await expect(
         rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
       ).to.be.revertedWith('ReentrancyGuard: reentrant call')
+    })
+  })
+
+  describe('pause', () => {
+    beforeEach(async () => {
+      await rentals.connect(deployer).initialize(owner.address, mana.address, collector.address, fee)
+    })
+
+    it('should pause the rentals contract', async () => {
+      await rentals.connect(owner).pause()
+      expect(await rentals.paused()).to.be.true
+    })
+
+    it('should revert when the caller is not the owner', async () => {
+      await expect(rentals.pause()).to.be.revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('should revert when the contract is already paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.connect(owner).pause()).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling acceptListing and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+
+      await expect(
+        rentals
+          .connect(tenant)
+          .acceptListing(
+            { ...listingParams, signature: await getListingSignature(lessor, rentals, listingParams) },
+            acceptListingParams.operator,
+            acceptListingParams.index,
+            acceptListingParams.rentalDays,
+            acceptListingParams.fingerprint
+          )
+      ).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling acceptOffer and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+
+      await expect(
+        rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
+      ).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling onERC721Received and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+
+      const bytes = ethers.utils.defaultAbiCoder.encode([offerEncodeType], [offerEncodeValue])
+
+      await expect(
+        land.connect(lessor)['safeTransferFrom(address,address,uint256,bytes)'](lessor.address, rentals.address, tokenId, bytes)
+      ).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling claim and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.claim([], [])).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling setUpdateOperator and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setUpdateOperator([], [], [])).to.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when calling setManyLandUpdateOperator and the contract is paused', async () => {
+      await rentals.connect(owner).pause()
+      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.be.revertedWith('Pausable: paused')
+    })
+  })
+
+  describe('unpause', () => {
+    beforeEach(async () => {
+      await rentals.connect(deployer).initialize(owner.address, mana.address, collector.address, fee)
+    })
+
+    it('should unpause the rentals contract', async () => {
+      await rentals.connect(owner).pause()
+      expect(await rentals.paused()).to.be.true
+      await rentals.connect(owner).unpause()
+      expect(await rentals.paused()).to.be.false
+    })
+
+    it('should allow calling acceptListing when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      await expect(
+        rentals
+          .connect(tenant)
+          .acceptListing(
+            { ...listingParams, signature: await getListingSignature(lessor, rentals, listingParams) },
+            acceptListingParams.operator,
+            acceptListingParams.index,
+            acceptListingParams.rentalDays,
+            acceptListingParams.fingerprint
+          )
+      ).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling acceptOffer when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      await expect(
+        rentals.connect(lessor).acceptOffer({ ...offerParams, signature: await getOfferSignature(tenant, rentals, offerParams) })
+      ).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling onERC721Received when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      const bytes = ethers.utils.defaultAbiCoder.encode([offerEncodeType], [offerEncodeValue])
+
+      await expect(
+        land.connect(lessor)['safeTransferFrom(address,address,uint256,bytes)'](lessor.address, rentals.address, tokenId, bytes)
+      ).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling claim when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      await expect(rentals.claim([], [])).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling setUpdateOperator when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      await expect(rentals.setUpdateOperator([], [], [])).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should allow calling setManyLandUpdateOperator when the contract is unpaused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+
+      await expect(rentals.setManyLandUpdateOperator(estate.address, estateId, [], [])).to.not.be.revertedWith('Pausable: paused')
+    })
+
+    it('should revert when the caller is not the owner', async () => {
+      await expect(rentals.unpause()).to.be.revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('should revert when the contract is already paused', async () => {
+      await rentals.connect(owner).pause()
+      await rentals.connect(owner).unpause()
+      await expect(rentals.connect(owner).unpause()).to.be.revertedWith('Pausable: not paused')
     })
   })
 })


### PR DESCRIPTION
Use OpenZeppelin PausableUpgradeable contract to add pause functionality.

Pausing will prevent usage of:
- acceptListing
- acceptOffer
- onERC721Received
- claim
- setUpdateOperator
- setManyLandUpdateOperator

~2K more gas consumed

Before:

```
·----------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                   Solc version: 0.8.7                    ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
···························································|···························|·············|······························
|  Methods                                                                                                                         │
·····························|·····························|·············|·············|·············|···············|··············
|  Contract                  ·  Method                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
·····························|·····························|·············|·············|·············|···············|··············
|  ERC721BasicToken          ·  safeTransferFrom           ·     329106  ·     411881  ·     354976  ·           17  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  acceptListing              ·     147905  ·     421899  ·     326710  ·           36  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  acceptOffer                ·     143503  ·     417497  ·     348047  ·           71  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  claim                      ·      25363  ·     211523  ·     122562  ·           14  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  setManyLandUpdateOperator  ·      32999  ·     187253  ·     140261  ·           13  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  setUpdateOperator          ·      26117  ·      84007  ·      62820  ·           11  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Deployments                                             ·                                         ·  % of limit   ·             │
···························································|·············|·············|·············|···············|··············
|  Rentals                                                 ·          -  ·          -  ·    3936539  ·       13.1 %  ·          -  │
·----------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

After

```
·----------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                   Solc version: 0.8.7                    ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
···························································|···························|·············|······························
|  Methods                                                                                                                         │
·····························|·····························|·············|·············|·············|···············|··············
|  Contract                  ·  Method                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
·····························|·····························|·············|·············|·············|···············|··············
|  ERC721BasicToken          ·  safeTransferFrom           ·     331188  ·     413963  ·     356437  ·           18  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  acceptListing              ·     149946  ·     423916  ·     329407  ·           37  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  acceptOffer                ·     145632  ·     419602  ·     350144  ·           72  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  claim                      ·      27511  ·     213241  ·     117886  ·           15  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  setManyLandUpdateOperator  ·      35037  ·     189291  ·     142299  ·           13  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Rentals                   ·  setUpdateOperator          ·      28221  ·      86111  ·      61865  ·           12  ·          -  │
·····························|·····························|·············|·············|·············|···············|··············
|  Deployments                                             ·                                         ·  % of limit   ·             │
···························································|·············|·············|·············|···············|··············
|  Rentals                                                 ·          -  ·          -  ·    4125086  ·       13.8 %  ·          -  │
·----------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```