### PR TITLE
feat: Remove static calls

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -548,8 +548,8 @@ contract Rentals is
     function _rent(RentParams memory _rentParams) private {
         IERC721Rentable asset = IERC721Rentable(_rentParams.contractAddress);
 
-        // If the provided contract support the verifyFingerprint function, validate the provided fingerprint.
-        if (_supportsVerifyFingerprint(asset)) {
+        // If the provided contract supports the verifyFingerprint function, validate the provided fingerprint.
+        if (asset.supportsInterface(InterfaceId_VerifyFingerprint)) {
             require(_verifyFingerprint(asset, _rentParams.tokenId, _rentParams.fingerprint), "Rentals#_rent: INVALID_FINGERPRINT");
         }
 
@@ -616,17 +616,6 @@ contract Rentals is
             _msgSender(),
             _rentParams.signature
         );
-    }
-
-    /// @dev Wrapper to static call IERC721Rentable.supportsInterface
-    function _supportsVerifyFingerprint(IERC721Rentable _asset) private view returns (bool) {
-        (bool success, bytes memory data) = address(_asset).staticcall(
-            abi.encodeWithSelector(_asset.supportsInterface.selector, InterfaceId_VerifyFingerprint)
-        );
-
-        require(success, "Rentals#_supportsVerifyFingerprint: SUPPORTS_INTERFACE_CALL_FAILURE");
-
-        return abi.decode(data, (bool));
     }
 
     /// @dev Wrapper to static call IERC721Rentable.verifyFingerprint

--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -550,7 +550,7 @@ contract Rentals is
 
         // If the provided contract supports the verifyFingerprint function, validate the provided fingerprint.
         if (asset.supportsInterface(InterfaceId_VerifyFingerprint)) {
-            require(_verifyFingerprint(asset, _rentParams.tokenId, _rentParams.fingerprint), "Rentals#_rent: INVALID_FINGERPRINT");
+            require(asset.verifyFingerprint(_rentParams.tokenId, abi.encode(_rentParams.fingerprint)), "Rentals#_rent: INVALID_FINGERPRINT");
         }
 
         Rental storage rental = rentals[_rentParams.contractAddress][_rentParams.tokenId];
@@ -616,21 +616,6 @@ contract Rentals is
             _msgSender(),
             _rentParams.signature
         );
-    }
-
-    /// @dev Wrapper to static call IERC721Rentable.verifyFingerprint
-    function _verifyFingerprint(
-        IERC721Rentable _asset,
-        uint256 _tokenId,
-        bytes32 _fingerprint
-    ) private view returns (bool) {
-        (bool success, bytes memory data) = address(_asset).staticcall(
-            abi.encodeWithSelector(_asset.verifyFingerprint.selector, _tokenId, abi.encode(_fingerprint))
-        );
-
-        require(success, "Rentals#_verifyFingerprint: VERIFY_FINGERPRINT_CALL_FAILURE");
-
-        return abi.decode(data, (bool));
     }
 
     /// @dev Transfer the erc20 tokens required to start a rent from the tenant to the lessor and the fee collector.


### PR DESCRIPTION
Closes #67 

Functions defined with `view` will always revert if the called contract attempts to update storage.

https://docs.soliditylang.org/en/latest/contracts.html#view-functions

"If the compiler’s EVM target is Byzantium or newer (default) the opcode STATICCALL is used when view functions are called, which enforces the state to stay unmodified as part of the EVM execution."