### PR TITLE
feat: Use _msgSender in onERC721Received

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -425,7 +425,7 @@ contract Rentals is
             // Check that the caller is the contract defined in the offer to ensure the function is being
             // called through an ERC721.safeTransferFrom.
             // Also check that the token id is the same as the one provided in the offer.
-            require(msg.sender == offer.contractAddress && offer.tokenId == _tokenId, "Rentals#onERC721Received: ASSET_MISMATCH");
+            require(_msgSender() == offer.contractAddress && offer.tokenId == _tokenId, "Rentals#onERC721Received: ASSET_MISMATCH");
 
             _acceptOffer(offer, _operator);
         }


### PR DESCRIPTION
Closes #70 

This function is intended to be called by safeTransfers so using _msgSender is unnecessary.
Yet, it might be good for consistency through the code base.