### PR TITLE
feat: Implement _disableInitializers in constructor

### DIFF
--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -130,6 +130,10 @@ contract Rentals is
         bytes _signature
     );
 
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Initialize the contract.
     /// @dev This method should be called as soon as the contract is deployed.
     /// Using this method in favor of a constructor allows the implementation of various kinds of proxies.

--- a/contracts/Rentals.sol
+++ b/contracts/Rentals.sol
@@ -131,6 +131,8 @@ contract Rentals is
     );
 
     constructor() {
+        // Prevents the implementation to be initialized.
+        // Initialization can only be done through a Proxy.
         _disableInitializers();
     }
 

--- a/contracts/mocks/RentalsProxy.sol
+++ b/contracts/mocks/RentalsProxy.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.7;
+
+import "@openzeppelin/contracts/proxy/Proxy.sol";
+
+/// @dev Contract used to test Rentals behind a proxy
+/// Implementation based on https://eips.ethereum.org/EIPS/eip-1967
+contract RentalsProxy is Proxy {
+    /// @dev This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    constructor(address _impl) {
+        StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = _impl;
+    }
+
+    function _implementation() internal view virtual override returns (address) {
+        return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+    }
+}
+
+library StorageSlot {
+    struct AddressSlot {
+        address value;
+    }
+
+    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+}

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -180,6 +180,7 @@ describe('Rentals', () => {
 
   afterEach(async () => {
     await network.provider.send('evm_revert', [snapshotId])
+    await network.provider.send('evm_setAutomine', [true])
   })
 
   describe('initialize', () => {

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -75,7 +75,7 @@ describe('Rentals', () => {
     const RentalsProxyFactory = await ethers.getContractFactory('RentalsProxy')
     const rentalsProxy = await RentalsProxyFactory.connect(deployer).deploy(rentalsImpl.address)
 
-    rentals = Rentals__factory.connect(rentalsProxy.address, deployer)
+    rentals = await ethers.getContractAt("Rentals", rentalsProxy.address)
 
     // Deploy and Prepare LANDRegistry
     const LANDRegistryFactory = await ethers.getContractFactory('LANDRegistry')

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -201,7 +201,7 @@ describe('Rentals', () => {
       const rentalsImpl = await ExtendedRentalsFactory.connect(deployer).deploy()
       const RentalsProxyFactory = await ethers.getContractFactory('RentalsProxy')
       const rentalsProxy = await RentalsProxyFactory.connect(deployer).deploy(rentalsImpl.address)
-      const rentals = ExtendedRentals__factory.connect(rentalsProxy.address, deployer)
+      const rentals = await ethers.getContractAt('ExtendedRentals', rentalsProxy.address)
 
       const zeroBytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
 

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -2,15 +2,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { BigNumber, BigNumberish } from 'ethers'
 import { ethers, network } from 'hardhat'
-import {
-  EstateRegistry,
-  ExtendedRentals__factory,
-  LANDRegistry,
-  MANAToken,
-  ReentrantERC721,
-  Rentals,
-  Rentals__factory,
-} from '../typechain-types'
+import { EstateRegistry, ExtendedRentals__factory, LANDRegistry, MANAToken, ReentrantERC721, Rentals, Rentals__factory } from '../typechain-types'
 import {
   daysToSeconds,
   ether,
@@ -75,7 +67,7 @@ describe('Rentals', () => {
     const RentalsProxyFactory = await ethers.getContractFactory('RentalsProxy')
     const rentalsProxy = await RentalsProxyFactory.connect(deployer).deploy(rentalsImpl.address)
 
-    rentals = await ethers.getContractAt("Rentals", rentalsProxy.address)
+    rentals = await ethers.getContractAt('Rentals', rentalsProxy.address)
 
     // Deploy and Prepare LANDRegistry
     const LANDRegistryFactory = await ethers.getContractFactory('LANDRegistry')
@@ -228,6 +220,15 @@ describe('Rentals', () => {
 
     it('should revert when initialized more than once', async () => {
       await expect(rentals.connect(deployer).initialize(owner.address, mana.address, collector.address, fee)).to.be.revertedWith(
+        'Initializable: contract is already initialized'
+      )
+    })
+
+    it('should revert when trying to initialize the implementation', async () => {
+      const RentalsFactory = await ethers.getContractFactory('Rentals')
+      const rentalsImpl = await RentalsFactory.connect(deployer).deploy()
+
+      await expect(rentalsImpl.initialize(owner.address, mana.address, collector.address, fee)).to.be.revertedWith(
         'Initializable: contract is already initialized'
       )
     })

--- a/test/Rentals.spec.ts
+++ b/test/Rentals.spec.ts
@@ -2,7 +2,15 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { BigNumber, BigNumberish } from 'ethers'
 import { ethers, network } from 'hardhat'
-import { EstateRegistry, ExtendedRentals, LANDRegistry, MANAToken, ReentrantERC721, Rentals } from '../typechain-types'
+import {
+  EstateRegistry,
+  ExtendedRentals__factory,
+  LANDRegistry,
+  MANAToken,
+  ReentrantERC721,
+  Rentals,
+  Rentals__factory,
+} from '../typechain-types'
 import {
   daysToSeconds,
   ether,
@@ -63,7 +71,11 @@ describe('Rentals', () => {
 
     // Deploy Rentals contract
     const RentalsFactory = await ethers.getContractFactory('Rentals')
-    rentals = await RentalsFactory.connect(deployer).deploy()
+    const rentalsImpl = await RentalsFactory.connect(deployer).deploy()
+    const RentalsProxyFactory = await ethers.getContractFactory('RentalsProxy')
+    const rentalsProxy = await RentalsProxyFactory.connect(deployer).deploy(rentalsImpl.address)
+
+    rentals = Rentals__factory.connect(rentalsProxy.address, deployer)
 
     // Deploy and Prepare LANDRegistry
     const LANDRegistryFactory = await ethers.getContractFactory('LANDRegistry')
@@ -192,8 +204,11 @@ describe('Rentals', () => {
     })
 
     it('should set eip712 name and version hashes', async () => {
-      const ExtendedRentals = await ethers.getContractFactory('ExtendedRentals')
-      const rentals: ExtendedRentals = await ExtendedRentals.connect(deployer).deploy()
+      const ExtendedRentalsFactory = await ethers.getContractFactory('ExtendedRentals')
+      const rentalsImpl = await ExtendedRentalsFactory.connect(deployer).deploy()
+      const RentalsProxyFactory = await ethers.getContractFactory('RentalsProxy')
+      const rentalsProxy = await RentalsProxyFactory.connect(deployer).deploy(rentalsImpl.address)
+      const rentals = ExtendedRentals__factory.connect(rentalsProxy.address, deployer)
 
       const zeroBytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
 


### PR DESCRIPTION
Closes #71 

NOTE:
To test the _disableInitializers and keep the tests working, now the rentals contract is tested through a proxy (as it is intended to be deployed)
The RentalsProxy mock is just intended for tests and is based on https://eips.ethereum.org/EIPS/eip-1967